### PR TITLE
Fix link to the recordings of Meetup vol. 5

### DIFF
--- a/content/events.json
+++ b/content/events.json
@@ -16,7 +16,7 @@
         {
             "title": "Student PL Meetup vol. 5",
             "date": "3. September 2025",
-            "recording": "https://youtu.be/awrKM2c24qU?si=ZZgmfuIc4Km9yj52",
+            "recording": "https://www.youtube.com/playlist?list=PLIsBvRXhzG5tDrCd1JZH2Egncb-Jr9ewW",
             "talks": [
                 "Zig Compiler Internals",
                 "Weird Stuff PowerShell Does II (part 2)",


### PR DESCRIPTION
The previous link pointed to the first video, not to the playlist